### PR TITLE
Add default argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine:3.5
 RUN apk add --no-cache wget
+CMD ["wget"]


### PR DESCRIPTION
Since this image is for wget it is useful to have to wget as default cmd. This allows it to be used like `docker run inutano/wget http://google.com`